### PR TITLE
feat: add V2 implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## [3.1.0] - 2023-05-10
-### Added
-- AmplitudeV2 HTTP client
-
 ## [3.0.0] - 2021-12-22
 ### Added
 - Ability to change the used HTTP client either via optional construct arg or `setClient` method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.1.0] - 2023-05-10
+### Added
+- AmplitudeV2 HTTP client
+
 ## [3.0.0] - 2021-12-22
 ### Added
 - Ability to change the used HTTP client either via optional construct arg or `setClient` method

--- a/src/AbstractAmplitude.php
+++ b/src/AbstractAmplitude.php
@@ -3,9 +3,7 @@
 namespace Luur\Amplitude;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\Psr7\Request;
 use JsonSerializable;
-use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -20,23 +18,7 @@ abstract class AbstractAmplitude
         $this->client = $client ?? $this->getDefaultClient();
     }
 
-    /**
-     * @param JsonSerializable $message
-     * @return ResponseInterface
-     * @throws ClientExceptionInterface
-     */
-    public function send(JsonSerializable $message): ResponseInterface
-    {
-        $params = $this->formatParams($message);
-
-        $headers = [
-            'Content-Type' => $this->getContentType(),
-        ];
-
-        $request = new Request('POST', $this->getApiUrl(), $headers, $params);
-
-        return $this->client->sendRequest($request);
-    }
+    abstract public function send(JsonSerializable $message): ResponseInterface;
 
     public function setClient(ClientInterface $client): void
     {
@@ -49,13 +31,4 @@ abstract class AbstractAmplitude
             'timeout' => 60.0,
         ]);
     }
-
-    protected function getContentType(): string
-    {
-        return 'application/x-www-form-urlencoded';
-    }
-
-    abstract protected function getApiUrl(): string;
-
-    abstract protected function formatParams(JsonSerializable $message): string;
 }

--- a/src/AbstractAmplitude.php
+++ b/src/AbstractAmplitude.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Luur\Amplitude;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Request;
+use JsonSerializable;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\ResponseInterface;
+
+abstract class AbstractAmplitude
+{
+    protected string $apiKey;
+    protected ClientInterface $client;
+
+    public function __construct(string $apiKey, ClientInterface $client = null)
+    {
+        $this->apiKey = $apiKey;
+        $this->client = $client ?? $this->getDefaultClient();
+    }
+
+    /**
+     * @param JsonSerializable $message
+     * @return ResponseInterface
+     * @throws ClientExceptionInterface
+     */
+    public function send(JsonSerializable $message): ResponseInterface
+    {
+        $params = $this->formatParams($message);
+
+        $headers = [
+            'Content-Type' => $this->getContentType(),
+        ];
+
+        $request = new Request('POST', $this->getApiUrl(), $headers, $params);
+
+        return $this->client->sendRequest($request);
+    }
+
+    public function setClient(ClientInterface $client): void
+    {
+        $this->client = $client;
+    }
+
+    protected function getDefaultClient(): ClientInterface
+    {
+        return new Client([
+            'timeout' => 60.0,
+        ]);
+    }
+
+    protected function getContentType(): string
+    {
+        return 'application/x-www-form-urlencoded';
+    }
+
+    abstract protected function getApiUrl(): string;
+
+    abstract protected function formatParams(JsonSerializable $message): string;
+}

--- a/src/AbstractAmplitude.php
+++ b/src/AbstractAmplitude.php
@@ -28,7 +28,10 @@ abstract class AbstractAmplitude
     protected function getDefaultClient(): ClientInterface
     {
         return new Client([
+            'base_uri' => $this->getBaseURI(),
             'timeout' => 60.0,
         ]);
     }
+
+    abstract public function getBaseURI(): string;
 }

--- a/src/Amplitude.php
+++ b/src/Amplitude.php
@@ -2,58 +2,20 @@
 
 namespace Luur\Amplitude;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\Psr7\Request;
 use JsonSerializable;
-use Psr\Http\Client\ClientExceptionInterface;
-use Psr\Http\Client\ClientInterface;
-use Psr\Http\Message\ResponseInterface;
 
-class Amplitude
+class Amplitude extends AbstractAmplitude
 {
-    public const API_URL = 'https://api.amplitude.com/httpapi';
-
-    protected string $apiKey;
-
-    protected ClientInterface $client;
-
-    public function __construct(string $apiKey, ClientInterface $client = null)
+    protected function getApiUrl(): string
     {
-        $this->apiKey = $apiKey;
-        $this->client = $client ?? $this->getDefaultClient();
+        return 'https://api.amplitude.com/httpapi';
     }
 
-    /**
-     * @param JsonSerializable $message
-     * @return ResponseInterface
-     * @throws ClientExceptionInterface
-     */
-    public function send(JsonSerializable $message): ResponseInterface
+    protected function formatParams(JsonSerializable $message): string
     {
-        $params = [
+        return http_build_query([
             'api_key' => $this->apiKey,
             'event' => json_encode($message, JSON_NUMERIC_CHECK),
-        ];
-
-        $headers = [
-            'Content-Type' => 'application/x-www-form-urlencoded',
-        ];
-
-        $request = new Request('POST', '', $headers, http_build_query($params));
-
-        return $this->client->sendRequest($request);
-    }
-
-    public function setClient(ClientInterface $client): void
-    {
-        $this->client = $client;
-    }
-
-    protected function getDefaultClient(): ClientInterface
-    {
-        return new Client([
-            'base_uri' => self::API_URL,
-            'timeout' => 60.0,
         ]);
     }
 }

--- a/src/Amplitude.php
+++ b/src/Amplitude.php
@@ -8,21 +8,26 @@ use Psr\Http\Message\ResponseInterface;
 
 class Amplitude extends AbstractAmplitude
 {
-    public const API_URL = 'https://api.amplitude.com/httpapi';
+    public const API_URI = 'https://api.amplitude.com/httpapi';
 
     public function send(JsonSerializable $message): ResponseInterface
     {
         $params = [
             'api_key' => $this->apiKey,
-            'event' => json_encode($message, JSON_NUMERIC_CHECK)
+            'event' => json_encode($message, JSON_NUMERIC_CHECK),
         ];
 
         $headers = [
             'Content-Type' => 'application/x-www-form-urlencoded',
         ];
 
-        $request = new Request('POST', self::API_URL, $headers, http_build_query($params));
+        $request = new Request('POST', '', $headers, http_build_query($params));
 
         return $this->client->sendRequest($request);
+    }
+
+    public function getBaseURI(): string
+    {
+        return self::API_URI;
     }
 }

--- a/src/Amplitude.php
+++ b/src/Amplitude.php
@@ -2,20 +2,27 @@
 
 namespace Luur\Amplitude;
 
+use GuzzleHttp\Psr7\Request;
 use JsonSerializable;
+use Psr\Http\Message\ResponseInterface;
 
 class Amplitude extends AbstractAmplitude
 {
-    protected function getApiUrl(): string
-    {
-        return 'https://api.amplitude.com/httpapi';
-    }
+    public const API_URL = 'https://api.amplitude.com/httpapi';
 
-    protected function formatParams(JsonSerializable $message): string
+    public function send(JsonSerializable $message): ResponseInterface
     {
-        return http_build_query([
+        $params = [
             'api_key' => $this->apiKey,
-            'event' => json_encode($message, JSON_NUMERIC_CHECK),
-        ]);
+            'event' => json_encode($message, JSON_NUMERIC_CHECK)
+        ];
+
+        $headers = [
+            'Content-Type' => 'application/x-www-form-urlencoded',
+        ];
+
+        $request = new Request('POST', self::API_URL, $headers, http_build_query($params));
+
+        return $this->client->sendRequest($request);
     }
 }

--- a/src/AmplitudeV2.php
+++ b/src/AmplitudeV2.php
@@ -11,6 +11,11 @@ class AmplitudeV2 extends AbstractAmplitude
         return 'https://api2.amplitude.com/2/httpapi';
     }
 
+    protected function getContentType(): string
+    {
+        return 'application/json';
+    }
+
     protected function formatParams(JsonSerializable $message): string
     {
         return json_encode([

--- a/src/AmplitudeV2.php
+++ b/src/AmplitudeV2.php
@@ -8,21 +8,27 @@ use Psr\Http\Message\ResponseInterface;
 
 class AmplitudeV2 extends AbstractAmplitude
 {
-    public const API_URL = 'https://api2.amplitude.com/2/httpapi';
+    public const API_URI = 'https://api2.amplitude.com/2/httpapi';
 
     public function send(JsonSerializable $message): ResponseInterface
     {
+        $events = $message->toArray();
         $params = [
             'api_key' => $this->apiKey,
-            'events' => [$message->toArray()],
+            'events' => count($events) > 1 ? $events : [$events],
         ];
 
         $headers = [
             'Content-Type' => 'application/json',
         ];
 
-        $request = new Request('POST', self::API_URL, $headers, json_encode($params));
+        $request = new Request('POST', '', $headers, json_encode($params));
 
         return $this->client->sendRequest($request);
+    }
+
+    public function getBaseURI(): string
+    {
+        return self::API_URI;
     }
 }

--- a/src/AmplitudeV2.php
+++ b/src/AmplitudeV2.php
@@ -2,25 +2,27 @@
 
 namespace Luur\Amplitude;
 
+use GuzzleHttp\Psr7\Request;
 use JsonSerializable;
+use Psr\Http\Message\ResponseInterface;
 
 class AmplitudeV2 extends AbstractAmplitude
 {
-    protected function getApiUrl(): string
-    {
-        return 'https://api2.amplitude.com/2/httpapi';
-    }
+    public const API_URL = 'https://api2.amplitude.com/2/httpapi';
 
-    protected function getContentType(): string
+    public function send(JsonSerializable $message): ResponseInterface
     {
-        return 'application/json';
-    }
-
-    protected function formatParams(JsonSerializable $message): string
-    {
-        return json_encode([
+        $params = [
             'api_key' => $this->apiKey,
             'events' => [$message->toArray()],
-        ]);
+        ];
+
+        $headers = [
+            'Content-Type' => 'application/json',
+        ];
+
+        $request = new Request('POST', self::API_URL, $headers, json_encode($params));
+
+        return $this->client->sendRequest($request);
     }
 }

--- a/src/AmplitudeV2.php
+++ b/src/AmplitudeV2.php
@@ -12,10 +12,9 @@ class AmplitudeV2 extends AbstractAmplitude
 
     public function send(JsonSerializable $message): ResponseInterface
     {
-        $events = $message->toArray();
         $params = [
             'api_key' => $this->apiKey,
-            'events' => count($events) > 1 ? $events : [$events],
+            'events' => $message->toArray(),
         ];
 
         $headers = [

--- a/src/AmplitudeV2.php
+++ b/src/AmplitudeV2.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Luur\Amplitude;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Request;
+use JsonSerializable;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class AmplitudeV2
+{
+    public const API_URL = 'https://api2.amplitude.com/2/httpapi';
+
+    protected string $apiKey;
+
+    protected ClientInterface $client;
+
+    public function __construct(string $apiKey, ClientInterface $client = null)
+    {
+        $this->apiKey = $apiKey;
+        $this->client = $client ?? $this->getDefaultClient();
+    }
+
+    /**
+     * @param JsonSerializable $message
+     * @return ResponseInterface
+     * @throws ClientExceptionInterface
+     */
+    public function send(JsonSerializable $message): ResponseInterface
+    {
+        $params = [
+            'api_key' => $this->apiKey,
+            'events' => [$message->toArray()],
+        ];
+
+        $headers = [
+            'Content-Type' => 'application/x-www-form-urlencoded',
+        ];
+
+        $request = new Request('POST', '', $headers, json_encode($params));
+
+        return $this->client->sendRequest($request);
+    }
+
+    public function setClient(ClientInterface $client): void
+    {
+        $this->client = $client;
+    }
+
+    protected function getDefaultClient(): ClientInterface
+    {
+        return new Client([
+            'base_uri' => self::API_URL,
+            'timeout' => 60.0,
+        ]);
+    }
+}

--- a/src/AmplitudeV2.php
+++ b/src/AmplitudeV2.php
@@ -2,58 +2,20 @@
 
 namespace Luur\Amplitude;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\Psr7\Request;
 use JsonSerializable;
-use Psr\Http\Client\ClientExceptionInterface;
-use Psr\Http\Client\ClientInterface;
-use Psr\Http\Message\ResponseInterface;
 
-class AmplitudeV2
+class AmplitudeV2 extends AbstractAmplitude
 {
-    public const API_URL = 'https://api2.amplitude.com/2/httpapi';
-
-    protected string $apiKey;
-
-    protected ClientInterface $client;
-
-    public function __construct(string $apiKey, ClientInterface $client = null)
+    protected function getApiUrl(): string
     {
-        $this->apiKey = $apiKey;
-        $this->client = $client ?? $this->getDefaultClient();
+        return 'https://api2.amplitude.com/2/httpapi';
     }
 
-    /**
-     * @param JsonSerializable $message
-     * @return ResponseInterface
-     * @throws ClientExceptionInterface
-     */
-    public function send(JsonSerializable $message): ResponseInterface
+    protected function formatParams(JsonSerializable $message): string
     {
-        $params = [
+        return json_encode([
             'api_key' => $this->apiKey,
             'events' => [$message->toArray()],
-        ];
-
-        $headers = [
-            'Content-Type' => 'application/x-www-form-urlencoded',
-        ];
-
-        $request = new Request('POST', '', $headers, json_encode($params));
-
-        return $this->client->sendRequest($request);
-    }
-
-    public function setClient(ClientInterface $client): void
-    {
-        $this->client = $client;
-    }
-
-    protected function getDefaultClient(): ClientInterface
-    {
-        return new Client([
-            'base_uri' => self::API_URL,
-            'timeout' => 60.0,
         ]);
     }
 }

--- a/tests/AmplitudeV2Test.php
+++ b/tests/AmplitudeV2Test.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Luur\Amplitude\Tests;
+
+use Exception;
+use GuzzleHttp\Psr7\Response;
+use Luur\Amplitude\Event;
+use Luur\Amplitude\AmplitudeV2;
+use GuzzleHttp\Client;
+use PHPUnit\Framework\TestCase;
+
+class AmplitudeV2Test extends TestCase
+{
+    public function testConstructsAmplitude(): void
+    {
+        $amp = new AmplitudeV2('test');
+        $this->assertTrue($amp instanceof AmplitudeV2);
+    }
+
+    public function testConstructsAmplitudeWithClient(): void
+    {
+        $amp = new AmplitudeV2('test', new Client());
+        $this->assertTrue($amp instanceof AmplitudeV2);
+    }
+
+    public function testHandlesEventSending(): void
+    {
+        $exception = new Exception('test exception');
+        $mockClient = $this->createMock(Client::class);
+        $mockClient->expects($this->once())->method('sendRequest')->willThrowException($exception);
+
+        $this->expectException(get_class($exception));
+
+        $amp = new AmplitudeV2('test', $mockClient);
+        $amp->send(new Event());
+    }
+
+    public function testReturnsResponse(): void
+    {
+        $response = new Response(200, [], 'test');
+
+        $mockClient = $this->createMock(Client::class);
+        $mockClient->expects($this->once())->method('sendRequest')->willReturn($response);
+
+        $amp = new AmplitudeV2('test', $mockClient);
+
+        $this->assertEquals($response, $amp->send(new Event()));
+    }
+
+    public function testSetsClient(): void
+    {
+        $amp = new AmplitudeV2('test');
+
+        $exception = new Exception('test exception');
+        $mockClient = $this->createMock(Client::class);
+        $mockClient->expects($this->once())->method('sendRequest')->willThrowException($exception);
+
+        $this->expectException(get_class($exception));
+        $this->expectExceptionMessage($exception->getMessage());
+
+        $amp->setClient($mockClient);
+        $amp->send(new Event());
+    }
+}


### PR DESCRIPTION
Amplitude has new v2 HTTP endpoint and param requirements. Add a new AmplitudeV2 class to adapt the library to this.